### PR TITLE
add a Reader class to abstract out the tokeniser/parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,4 @@ help: ## Show this help message.
 	echo "usage: make [target] ..."
 	echo ""
 	echo "targets:"
-	fgrep --no-filename "##" $(MAKEFILE_LIST) | fgrep --invert-match $$'\t' | sed -e 's/: ## / - /'
+	egrep '^(.+)\:\ ##\ (.+)' ${MAKEFILE_LIST} | column -t -c 2 -s ':#'

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -38,7 +38,7 @@ class Parser implements ParserInterface
     /**
      * @param Iterator $tokens
      *
-     * @return Iterator Iterator of csv line Iterators
+     * @return Iterator Iterator of csv line arrays
      */
     public function parse(Iterator $tokens)
     {

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Graze\CsvToken;
+
+use Graze\CsvToken\Csv\CsvConfigurationInterface;
+use Graze\CsvToken\Tokeniser\StreamTokeniser;
+use Iterator;
+
+class Reader
+{
+    /** @var resource */
+    private $stream;
+    /** @var CsvConfigurationInterface */
+    private $config;
+
+    /**
+     * Reader constructor.
+     *
+     * @param CsvConfigurationInterface $config
+     * @param resource                  $stream
+     */
+    public function __construct(CsvConfigurationInterface $config, $stream)
+    {
+        $this->stream = $stream;
+        $this->config = $config;
+    }
+
+    /**
+     * @return Iterator Iterator of csv line arrays
+     */
+    public function read()
+    {
+        $tokens = new StreamTokeniser($this->config, $this->stream);
+        $parser = new Parser();
+        return $parser->parse($tokens->getTokens());
+    }
+}

--- a/tests/integration/ReaderTest.php
+++ b/tests/integration/ReaderTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of graze/csv-token
+ *
+ * Copyright (c) 2016 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/csv-token/blob/master/LICENSE.md
+ * @link    https://github.com/graze/csv-token
+ */
+
+namespace Graze\CsvToken\Test\Unit;
+
+use Graze\CsvToken\Csv\CsvConfiguration;
+use Graze\CsvToken\Csv\CsvConfigurationInterface;
+use Graze\CsvToken\Reader;
+use Graze\CsvToken\Test\TestCase;
+use Mockery as m;
+
+class ReaderTest extends TestCase
+{
+    /**
+     * @dataProvider parseData
+     *
+     * @param CsvConfigurationInterface $config
+     * @param string                    $csv
+     * @param array                     $expected
+     */
+    public function testParse(CsvConfigurationInterface $config, $csv, array $expected)
+    {
+        $reader = new Reader($config, $this->getStream($csv));
+
+        $results = iterator_to_array($reader->read());
+
+        static::assertEquals($expected, $results);
+    }
+
+    /**
+     * @return array
+     */
+    public function parseData()
+    {
+        return [
+            [
+                new CsvConfiguration(),
+                '"some",\\N,"new' . "\n" . 'line",with\\' . "\n" . 'escaped,"in\\' . "\n" . 'quotes","\\\\"',
+                [
+                    ['some', null, "new\nline", "with\nescaped", "in\nquotes", '\\'],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -15,4 +15,16 @@ namespace Graze\CsvToken\Test;
 
 class TestCase extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @param string $string
+     *
+     * @return resource
+     */
+    protected function getStream($string)
+    {
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $string);
+        rewind($stream);
+        return $stream;
+    }
 }

--- a/tests/unit/Tokeniser/StreamTokeniserTest.php
+++ b/tests/unit/Tokeniser/StreamTokeniserTest.php
@@ -54,19 +54,6 @@ class StreamTokeniserTest extends TestCase
     }
 
     /**
-     * @param string $string
-     *
-     * @return resource
-     */
-    private function getStream($string)
-    {
-        $stream = fopen('php://memory', 'r+');
-        fwrite($stream, $string);
-        rewind($stream);
-        return $stream;
-    }
-
-    /**
      * @return array
      */
     public function tokeniserTestData()


### PR DESCRIPTION
- Adds `Reader` class so when doing simple reading, the tokeniser/parser is abstracted
